### PR TITLE
[OSS-64] Add templates for bug reports, feature requests and pull requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[BUG]"
+labels: "bug"
+assignees: "black-bunny-brigade"
+
+---
+
+<!--- Before creating a bug report, please, answer the following questions -->
+<!--- Did you check the documentation for answers? -->
+<!--- Did you make sure that this bug has not already been reported? -->
+
+## Expected Behavior
+<!--- Tell us what should happen -->
+<!--- For example: When I [do X], it should [produce Y] -->
+
+## Actual Behavior
+<!--- Tell us what happens instead -->
+<!--- For example: When I [did X], it [produced Y] -->
+
+## Possible Fix
+<!--- Optionally suggest a fix or work around -->
+
+## To Reproduce
+<!--- Optionally provide a link to a live example -->
+
+<!--- Otherwise, please provide a set of reproduction steps -->
+1.
+2.
+3.
+4.
+
+## Additional Information
+<!--- Include any relevant details about your environment (branch, browser, OS) -->
+<!--- and the bug (screenshots, logs, etc) -->
+
+**I will abide by the [code of conduct](https://github.com/fastruby/benches/blob/main/code-of-conduct.md)**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,24 @@
+---
+name: Feature request
+about: Request a new feature
+title: "[REQUEST]"
+labels: 'enhancement'
+assignees: ''
+
+---
+
+<!--- Before creating a feature request, please, answer the following questions -->
+<!--- Did you check the documentation for this feature? -->
+<!--- Did you make sure that this feature has not already been requested? -->
+
+## Description
+<!--- Provide a description of the change or addition you are proposing -->
+
+## Possible Implementation
+<!--- Optionally suggest an idea to implement or a workaround to fix the issue -->
+
+## Resources:
+<!--- If you have resources related to the implementation or research for this feature, add them here. -->
+<!--- If possible, include any mockup ideas related to the requested feature. -->
+
+**I will abide by the [code of conduct](https://github.com/fastruby/benches/blob/main/code-of-conduct.md)**

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,0 +1,76 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to make participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all project spaces, and it also applies when
+an individual is representing the project or its community in public spaces.
+Examples of representing a project or community include using an official
+project e-mail address, posting via an official social media account, or acting
+as an appointed representative at an online or offline event. Representation of
+a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at [oss@ombulabs.com]. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,17 @@
+<!--- Please read the README before submitting pull requests for this project. -->
+
+## Description
+<!--- Describe your changes in detail -->
+
+## Motivation and Context
+<!--- Why is this change required? What problem does it solve? -->
+<!--- If it fixes an open issue, please link to the issue here. -->
+
+## How Has This Been Tested?
+<!--- Include any relevant details about your testing environment and the steps you followed -->
+<!--- For example: I am using [Safari|Firefox|Chrome] then I visit [the users path] -->
+
+## Screenshots:
+<!-- Add screenshots (applicable to any UI changes) -->
+
+**I will abide by the [code of conduct](code-of-conduct.md)**


### PR DESCRIPTION
This merely adds the above templates as per [this RFC](https://github.com/fastruby/RFCs/blob/main/2021-10-13-github-templates.md)